### PR TITLE
fix: mutable default context

### DIFF
--- a/pydid/doc/builder.py
+++ b/pydid/doc/builder.py
@@ -169,8 +169,6 @@ class ServiceBuilder:
 class DIDDocumentBuilder:
     """Builder for constructing DID Documents programmatically."""
 
-    DEFAULT_CONTEXT = ["https://www.w3.org/ns/did/v1"]
-
     def __init__(
         self,
         id: Union[str, DID],
@@ -181,7 +179,7 @@ class DIDDocumentBuilder:
     ):
         """Initliaze builder."""
         self.id: DID = DID(id)
-        self.context = context or self.DEFAULT_CONTEXT
+        self.context = context or self.__default_context()
         self.also_known_as = also_known_as
         self.controller = controller
         self.verification_method = VerificationMethodBuilder(self.id)
@@ -196,6 +194,10 @@ class DIDDocumentBuilder:
         )
         self.service = ServiceBuilder(self.id)
         self.extra = {}
+
+    @staticmethod
+    def __default_context() -> List[str]:
+        return ["https://www.w3.org/ns/did/v1"]
 
     @classmethod
     def from_doc(cls, doc: DIDDocument) -> "DIDDocumentBuilder":

--- a/tests/doc/test_doc.py
+++ b/tests/doc/test_doc.py
@@ -700,3 +700,18 @@ def test_relative_ids(cls):
 def test_listify():
     doc = DIDDocumentRoot.deserialize({"id": "did:example:123", "controller": None})
     assert doc.controller is None
+
+
+def test_default_context_should_not_mutate():
+    # given
+
+    doc_builder = DIDDocumentBuilder("did:example:123")
+    # save a copy of the default context before mutating the document's contexts
+    original_default_context = [context for context in doc_builder.context]
+
+    # when
+
+    doc_builder.context.append("https://some-required-context")
+
+    # then
+    assert DIDDocumentBuilder("did:example:123").context == original_default_context


### PR DESCRIPTION
Fix a small issue where mutating the context list of a `DIDDocumentBuilder` created using the `DEFAULT_CONTEXT` will impact the default context of subsequent `DIDDocumentBuilder` instances.