### PR TITLE
add = to valid characters in regex

### DIFF
--- a/pydid/common.py
+++ b/pydid/common.py
@@ -1,7 +1,7 @@
 """Common components."""
 import re
 
-DID_REGEX = "did:([a-z0-9]+):((?:[a-zA-Z0-9._%-]*:)*[a-zA-Z0-9._%-]+)"
+DID_REGEX = "did:([a-z0-9]+):((?:[a-zA-Z0-9._%-]*:)*[a-zA-Z0-9._%-=]+)"
 DID_PATTERN = re.compile(f"^{DID_REGEX}$")
 DID_URL_DID_PART_PATTERN = re.compile(f"^({DID_REGEX})[?/#]")
 DID_URL_RELATIVE_FRONT = re.compile("^[?/#].*")


### PR DESCRIPTION
b64 encoded entries may be padded with ='s.

Proposed Change to #61 