### PR TITLE
VerificationMethod.controller can be reference for did:peer:2

### DIFF
--- a/pydid/verification_method.py
+++ b/pydid/verification_method.py
@@ -37,7 +37,7 @@ class VerificationMethod(Resource):
 
     id: DIDUrl
     type: str
-    controller: DID
+    controller: Union[DID, DIDUrl]
     public_key_hex: Optional[str] = None
     public_key_base58: Optional[str] = None
     public_key_pem: Optional[str] = None

--- a/tests/test_verification_method.py
+++ b/tests/test_verification_method.py
@@ -146,6 +146,18 @@ def test_validator_allow_controller_list():
     assert vmethod.controller == "did:example:123"
 
 
+def test_validator_allow_controller_didurl():
+    # https://identity.foundation/peer-did-method-spec/#generation-method
+    vmethod = VerificationMethod.deserialize(
+        {
+            "id": "did:example:123#keys-1",
+            "type": "Ed25519Signature2018",
+            "controller": "#id",
+            "publicKeyBase58": "12345",
+        },
+    )
+    assert vmethod.controller == "#id"
+
 def test_validator_allow_missing_controller():
     vmethod = VerificationMethod.deserialize(
         {


### PR DESCRIPTION
https://identity.foundation/peer-did-method-spec/#generation-method

This spec specifically allows for `#id` to be an acceptable value for a controller and act as a reference to the DIDDocument ID without needing to populate it with the full value. 