### PR TITLE
feat: add recips and routes by url to service builder

### DIFF
--- a/pydid/doc/builder.py
+++ b/pydid/doc/builder.py
@@ -137,8 +137,8 @@ class ServiceBuilder:
     def add_didcomm(
         self,
         service_endpoint: str,
-        recipient_keys: List[VerificationMethod],
-        routing_keys: Optional[List[VerificationMethod]] = None,
+        recipient_keys: List[Union[VerificationMethod, DIDUrl, str]],
+        routing_keys: Optional[List[Union[VerificationMethod, DIDUrl, str]]] = None,
         *,
         priority: Optional[int] = None,
         type_: Optional[str] = None,
@@ -152,8 +152,14 @@ class ServiceBuilder:
         service = DIDCommService.make(
             id=self._did.ref(ident),
             service_endpoint=service_endpoint,
-            recipient_keys=[vmethod.id for vmethod in recipient_keys],
-            routing_keys=[vmethod.id for vmethod in routing_keys],
+            recipient_keys=[
+                vmethod.id if isinstance(vmethod, VerificationMethod) else vmethod
+                for vmethod in recipient_keys
+            ],
+            routing_keys=[
+                vmethod.id if isinstance(vmethod, VerificationMethod) else vmethod
+                for vmethod in routing_keys
+            ],
             type=type_,
             priority=priority,
             accept=accept,

--- a/tests/doc/test_doc.py
+++ b/tests/doc/test_doc.py
@@ -6,7 +6,7 @@ import copy
 import pytest
 from typing_extensions import Annotated, Literal
 
-from pydid.did_url import InvalidDIDUrlError
+from pydid.did_url import DIDUrl, InvalidDIDUrlError
 from pydid.doc.builder import DIDDocumentBuilder
 from pydid.doc.doc import (
     DIDDocument,
@@ -467,6 +467,8 @@ def test_programmatic_construction_didcomm():
     route = builder.verification_method.add(
         ExampleVerificationMethod, public_key_example="abcd"
     )
+    another_route = DIDUrl("did:example:123#key-5")
+    yet_another_route = "did:example:123#key-6"
     builder.service.add_didcomm(
         service_endpoint="https://example.com",
         recipient_keys=[key],
@@ -476,7 +478,7 @@ def test_programmatic_construction_didcomm():
     builder.service.add_didcomm(
         service_endpoint="https://example.com",
         recipient_keys=[key],
-        routing_keys=[route],
+        routing_keys=[route, another_route, yet_another_route],
     )
     assert builder.build().serialize() == {
         "@context": ["https://www.w3.org/ns/did/v1"],
@@ -510,7 +512,11 @@ def test_programmatic_construction_didcomm():
                 "type": "did-communication",
                 "serviceEndpoint": "https://example.com",
                 "recipientKeys": ["did:example:123#key-0"],
-                "routingKeys": ["did:example:123#key-1"],
+                "routingKeys": [
+                    "did:example:123#key-1",
+                    "did:example:123#key-5",
+                    "did:example:123#key-6",
+                ],
                 "priority": 1,
             },
         ],


### PR DESCRIPTION
This makes the `add_didcomm` helper on the service builder a bit more useful.