### PR TITLE
feat: realign service with DID Core spec

### DIFF
--- a/pydid/service.py
+++ b/pydid/service.py
@@ -1,18 +1,16 @@
 """DID Doc Service."""
 
-from typing import List, Optional, Union
-
-from pydantic import Extra, AnyUrl
+from typing import Any, List, Mapping, Optional, Union
 from typing_extensions import Literal
 
+from pydantic import AnyUrl, Extra, StrictStr
+
+from .did import DID
 from .did_url import DIDUrl
 from .resource import Resource
 
 
-class ServiceEndpoint(Resource):
-    """List of Service Endpoints."""
-
-    uri: Union[DIDUrl, AnyUrl]
+EndpointStrings = Union[DID, DIDUrl, AnyUrl, StrictStr]
 
 
 class Service(Resource):
@@ -20,7 +18,11 @@ class Service(Resource):
 
     id: DIDUrl
     type: str
-    service_endpoint: Union[DIDUrl, AnyUrl, Literal[""], List[ServiceEndpoint]]
+    service_endpoint: Union[
+        EndpointStrings,
+        List[Union[EndpointStrings, Mapping[str, Any]]],
+        Mapping[str, Any],
+    ]
 
 
 class DIDCommV1Service(Service):
@@ -34,6 +36,7 @@ class DIDCommV1Service(Service):
     type: Literal[
         "IndyAgent", "did-communication", "DIDCommMessaging"
     ] = "did-communication"
+    service_endpoint: EndpointStrings
     recipient_keys: List[DIDUrl]
     routing_keys: List[DIDUrl] = []
     accept: Optional[List[str]] = None
@@ -43,10 +46,10 @@ class DIDCommV1Service(Service):
 DIDCommService = DIDCommV1Service
 
 
-class DIDCommV2ServiceEndpoint(ServiceEndpoint):
+class DIDCommV2ServiceEndpoint(Resource):
     """DID Communication Service Endpoint."""
 
-    uri: Union[DIDUrl, AnyUrl]
+    uri: EndpointStrings
     accept: Optional[List[str]] = None
     routing_keys: List[DIDUrl] = []
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -36,6 +36,14 @@ SERVICES = [
         "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
     },
     {
+        "id": "did:example:123#didcomm-1",
+        "type": "did-communication",
+        "serviceEndpoint": "didcomm:transport/queue",
+        "recipientKeys": ["did:example:123#keys-1"],
+        "routingKeys": [],
+        "accept": ["didcomm/aip2;env=rfc587"],
+    },
+    {
         "id": "did:example:123456789abcdefghi#didcomm-1",
         "type": "DIDCommMessaging",
         "serviceEndpoint": [
@@ -63,11 +71,6 @@ INVALID_SERVICES = [
         "id": "did:example:123#linked-domain",
         "type": "LinkedDomains",
         "serviceEndpoint": True,
-    },
-    {
-        "id": "did:example:123456789abcdefghi#didcomm-1",
-        "type": "DIDCommMessaging",
-        "serviceEndpoint": ["http://example.com"],
     },
 ]
 
@@ -128,6 +131,15 @@ DIDCOMM_SERVICES = [
         "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
     },
     {
+        "id": "did:example:123#didcomm-1",
+        "type": "did-communication",
+        "serviceEndpoint": "didcomm:transport/queue",
+        "recipientKeys": ["did:example:123#keys-1"],
+        "routingKeys": [],
+        "priority": 0,
+        "accept": ["didcomm/aip2;env=rfc587"],
+    },
+    {
         "id": "did:example:123456789abcdefghi#didcomm-1",
         "type": "DIDCommMessaging",
         "serviceEndpoint": [
@@ -135,6 +147,28 @@ DIDCOMM_SERVICES = [
                 "uri": "https://example.com/path",
                 "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
                 "routingKeys": ["did:example:somemediator#somekey"],
+            }
+        ],
+    },
+    {
+        "id": "did:example:123456789abcdefghi#didcomm-1",
+        "type": "DIDCommMessaging",
+        "serviceEndpoint": [
+            {
+                "uri": "didcomm:transport/queue",
+                "accept": ["didcomm/v2"],
+                "routingKeys": [],
+            }
+        ],
+    },
+    {
+        "id": "did:example:123456789abcdefghi#didcomm-1",
+        "type": "DIDCommMessaging",
+        "serviceEndpoint": [
+            {
+                "uri": "did:example:mediator",
+                "accept": ["didcomm/v2"],
+                "routingKeys": [],
             }
         ],
     },


### PR DESCRIPTION
This PR realigns the service endpoint definitions to what is outlined in the DID Core spec. Specifically, permitting the service endpoint to be a string, map, or set of strings and/or maps. DIDs, DID URLs, general URLs, and now any string is now permitted. This is to support specifying arbitrary URIs. The rules for parsing URIs would be overly complicated to fully validate; slightly greater flexibility is preferrable to maintaining large regexes.

Through this realignment, pydid will now support `didcomm:transport/queue` as a `serviceEndpoint` value.