### PR TITLE
fix(backport 0.3.x): align with DIDComm v2.1 spec for service endpoints

### DIFF
--- a/pydid/service.py
+++ b/pydid/service.py
@@ -63,7 +63,7 @@ class DIDCommV2Service(Service):
         extra = Extra.forbid
 
     type: Literal["DIDCommMessaging"] = "DIDCommMessaging"
-    service_endpoint: List[DIDCommV2ServiceEndpoint]
+    service_endpoint: Union[List[DIDCommV2ServiceEndpoint], DIDCommV2ServiceEndpoint]
 
 
 class UnknownService(Service):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -54,6 +54,15 @@ SERVICES = [
             }
         ],
     },
+    {
+        "id": "did:example:123456789abcdefghi#didcomm-1",
+        "type": "DIDCommMessaging",
+        "serviceEndpoint": {
+            "uri": "https://example.com/path",
+            "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
+            "routingKeys": ["did:example:somemediator#somekey"],
+        },
+    },
 ]
 
 INVALID_SERVICES = [
@@ -171,6 +180,15 @@ DIDCOMM_SERVICES = [
                 "routingKeys": [],
             }
         ],
+    },
+    {
+        "id": "did:example:123456789abcdefghi#didcomm-1",
+        "type": "DIDCommMessaging",
+        "serviceEndpoint": {
+            "uri": "https://example.com/path",
+            "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
+            "routingKeys": ["did:example:somemediator#somekey"],
+        },
     },
 ]
 

--- a/tests/test_verification_method.py
+++ b/tests/test_verification_method.py
@@ -162,6 +162,14 @@ def test_validator_allow_missing_controller():
                 "publicKeyBase58": "12345",
             },
         )
+    with pytest.raises(ValueError):
+        vmethod = VerificationMethod.deserialize(
+            {
+                "id": "hi",
+                "type": "Ed25519Signature2018",
+                "publicKeyBase58": "12345",
+            },
+        )
 
 
 def test_make():


### PR DESCRIPTION
[Version 2.1 of the spec](https://identity.foundation/didcomm-messaging/spec/v2.1/) defines the expected value for `serviceEndpoint` as:

> ... a serviceEndpoint MUST contain an object or an array of objects.

This differs from 2.0 in that a list of objects was previously required. This PR adjusts the validator for DIDComm v2 service objects accordingly.