### PR TITLE
:art: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Python library for validating, constructing, and representing DIDs and DID Docum
 Using a virtual environment is generally recommended:
 
 ```sh
-$ python -m venv env
-$ source env/bin/activate
+python -m venv env
+source env/bin/activate
 ```
 
 Install with pip:
 
 ```sh
-$ pip install pydid
+pip install pydid
 ```
 
 ## Development
@@ -28,12 +28,11 @@ To begin making code changes, clone this repo and do the following to install
 dependencies:
 
 ```sh
-$ python -m venv env
-$ source env/bin/activate
-$ pip install poetry
-$ poetry install
+python -m venv env
+source env/bin/activate
+pip install poetry
+poetry install
 ```
-
 
 ## Contributing
 

--- a/pydid/did.py
+++ b/pydid/did.py
@@ -1,6 +1,6 @@
 """W3C DID Representation.
 
-DID Parsing rules derived from W3C Decentrialized Identifiers v1.0 Working Draft 18
+DID Parsing rules derived from W3C Decentralized Identifiers v1.0 Working Draft 18
 January 2021:
 
     https://w3c.github.io/did-core/

--- a/pydid/validation.py
+++ b/pydid/validation.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError, root_validator
 
 @contextmanager
 def wrap_validation_error(error_to_raise: Type[Exception], message: str = None):
-    """Wrap validation erros with more friendly errors."""
+    """Wrap validation errors with more friendly errors."""
     try:
         yield
     except ValidationError as error:

--- a/pydid/verification_method.py
+++ b/pydid/verification_method.py
@@ -215,10 +215,10 @@ class Bls1238G2Key2020(VerificationMethod):
     public_key_base58: str
 
 
-class GpgVerifcationKey2020(VerificationMethod):
-    """GpgVerifcationKey2020 VerificationMethod."""
+class GpgVerificationKey2020(VerificationMethod):
+    """GpgVerificationKey2020 VerificationMethod."""
 
-    type: Literal["GpgVerifcationKey2020"]
+    type: Literal["GpgVerificationKey2020"]
     public_key_gpg: str
 
 
@@ -281,7 +281,7 @@ KnownVerificationMethods = Union[
     EcdsaSecp256k1VerificationKey2019,
     Bls1238G1Key2020,
     Bls1238G2Key2020,
-    GpgVerifcationKey2020,
+    GpgVerificationKey2020,
     RsaVerificationKey2018,
     X25519KeyAgreementKey2019,
     X25519KeyAgreementKey2020,

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -36,7 +36,7 @@ def test_resource_json_transforms():
 def test_dereference_as_compatible(mock_indexed_resource):
     class One(Resource):
         common: str
-        optiona: Optional[str] = None
+        optional: Optional[str] = None
 
     class Two(Resource):
         common: str


### PR DESCRIPTION
Mostly minor typo fixes (and markdown warning fixes in README), but one noteworthy change is a VerificationMethod which was spelled:
```
GpgVerifcationKey2020
```

is now
```
GpgVerificationKey2020
```

Probably considered a breaking change.

Signed-off-by: ff137 <ff137@proton.me>