### PR TITLE
:construction_worker: Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,6 @@ updates:
 
   # Maintain pip dependencies
   - package-ecosystem: pip
+    directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
My bad. `directory: /` is missing in the pip config

Signed-off-by: ff137 <ff137@proton.me>