### PR TITLE
Fix failing PyPi publish workflow, bumping Python version to 3.14.

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,8 @@ name: Upload PyDID To PyPI
 on:
   release:
     types: [ created ]
+  push:
+    branches: [ "main" ]
 
 jobs:
   deploy:
@@ -12,10 +14,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: 3.14
           cache: poetry
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,9 +2,7 @@ name: Upload PyDID To PyPI
 
 on:
   release:
-    types: [ created ]
-  push:
-    branches: [ "main" ]
+    types: [created]
 
 jobs:
   deploy:


### PR DESCRIPTION
Addresses setup-python@v5 behaviour, parsing 3.10 as 3.1. Bumped setup-python to v6, and bumped python version to 3.14.

cc: @dbluhm 